### PR TITLE
#77 - Hide events tab when no intermediate events in BPMN

### DIFF
--- a/src/components/SimulationParameters.tsx
+++ b/src/components/SimulationParameters.tsx
@@ -34,7 +34,7 @@ import AllIntermediateEvents from './interEvents/AllIntermediateEvents'
 import EventIcon from '@mui/icons-material/Event';
 import AllBatching from './batching/AllBatching';
 import DynamicFeedIcon from '@mui/icons-material/DynamicFeed';
-import { Dictionary } from './modelData';
+import useTabVisibility, {TABS} from './simulationParameters/useTabVisibility';
 
 const useStyles = makeStyles( (theme: Theme) => ({
     simParamsGrid: {
@@ -47,28 +47,6 @@ const useStyles = makeStyles( (theme: Theme) => ({
         "& .Mui-active": { color: theme.palette.info.dark }
     }
 }));
-
-enum TABS {
-    CASE_CREATION,
-    RESOURCE_CALENDARS,
-    RESOURCES,
-    RESOURCE_ALLOCATION,
-    BRANCHING_PROB,
-    INTERMEDIATE_EVENTS,
-    BATCHING,
-    SIMULATION_RESULTS
-}
-
-const tabs_name : { [key: string]: string } = {
-    CASE_CREATION: "Case Creation",
-    RESOURCE_CALENDARS: "Resource Calendars",
-    RESOURCES: "Resources",
-    RESOURCE_ALLOCATION: "Resource Allocation",
-    BRANCHING_PROB: "Branching Probabilities",
-    INTERMEDIATE_EVENTS: "Intermediate Events",
-    BATCHING: "Batching",
-    SIMULATION_RESULTS: "Simulation Results"
-};
 
 const tooltip_desc: { [key: string]: string } = {
     CASE_CREATION: 
@@ -136,41 +114,9 @@ const SimulationParameters = () => {
     const { formState: { errors, isValid, isSubmitted, submitCount }, getValues, handleSubmit } = formState
     const [ isScenarioParamsValid, setIsScenarioParamsValid ] = useState(true)
 
-    const [ visibleTabs, setVisibleTabs ] = useState(new Dictionary<string>())
-    const [ isEventsTabHidden, setIsEventsTabHidden ] = useState<boolean | undefined>(undefined)
+    const { visibleTabs } = useTabVisibility(eventsFromModel)
 
     const { onUploadNewModel } = useNewModel()
-
-    useEffect(() => {
-        if (eventsFromModel === undefined)
-            return
-
-        const areEventsEmpty = eventsFromModel.isEmpty()
-        if (areEventsEmpty !== isEventsTabHidden) {
-            setIsEventsTabHidden(areEventsEmpty)
-        }
-    }, [eventsFromModel])
-
-    useEffect(() => {
-        if (isEventsTabHidden === undefined || !visibleTabs.isEmpty()) {
-            // skip initialization if
-            // 1) no information yet loaded
-            // 2) we already have a final array
-            return 
-        }
-
-        const newVisibleTabs = Object.entries(tabs_name).reduce((acc: Dictionary<string>, [key, value]: any) => {
-            if (key === TABS[TABS.INTERMEDIATE_EVENTS] && isEventsTabHidden) {
-                // section is hidden, we don't add it to the general list
-                return acc
-            }
-
-            acc.add(key, value)
-            return acc
-        }, new Dictionary<string>())
-
-        setVisibleTabs(newVisibleTabs)
-    }, [isEventsTabHidden, visibleTabs])
 
     // validate both forms: scenatio params and json fields
     useEffect(() => {

--- a/src/components/interEvents/EventCard.tsx
+++ b/src/components/interEvents/EventCard.tsx
@@ -43,11 +43,11 @@ const EventCard = (props: EventCardProps) => {
     }, [currentField, eventIdKey])
 
     useEffect(() => {
-        if (eventsFromModel && Object.keys(eventsFromModel).includes(eventIdKey)) {
+        if (eventsFromModel && eventsFromModel.isKeyExisting(eventIdKey)) {
             // checking the edge case
             // double verifying that event with this id exists in the model
             // if yes, update the state with event label
-            setEventLabel(eventsFromModel[eventIdKey].name)
+            setEventLabel(eventsFromModel.getNameByKey(eventIdKey))
         }
     }, [eventsFromModel, eventIdKey])
 

--- a/src/components/modelData.ts
+++ b/src/components/modelData.ts
@@ -23,6 +23,49 @@ export interface SequenceElements {
     }
 }
 
-export interface EventsFromModel extends SequenceElements {
+export class Dictionary<T> {
+    items: { [key: string]: T } = {}
 
+    add(key: string, value: T) {
+        this.items[key] = value
+    }
+
+    remove(key: string) {
+        delete this.items[key]
+    }
+
+    isEmpty() {
+        return Object.keys(this.items).length === 0;
+    }
+
+    getValueByKey(key: string) {
+        return  (key in this.items) ? this.items[key] : null
+    }
+
+    isKeyExisting(key: string) {
+        return Object.keys(this.items).includes(key)
+    }
+
+    getAllItems() {
+        return this.items
+    }
+
+    getAllKeys() {
+        return Object.keys(this.items)
+    }
+}
+
+export class EventDetails {
+    name: string
+
+    constructor(init: {name: string}) {
+        this.name = init.name
+    }
+}
+
+export class EventsFromModel extends Dictionary<EventDetails> {
+    getNameByKey(key: string) {
+        " Returns name or empty string"
+        return this.getValueByKey(key)?.name ?? ""
+    }
 }

--- a/src/components/simulationParameters/useBpmnFile.ts
+++ b/src/components/simulationParameters/useBpmnFile.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import BpmnModdle from "bpmn-moddle";
 import BpmnModeler from "bpmn-js/lib/Modeler";
-import { AllModelTasks, EventsFromModel, Gateways, SequenceElements } from '../modelData';
+import { AllModelTasks, EventsFromModel, Gateways, SequenceElements, EventDetails } from '../modelData';
 
 const useBpmnFile = (bpmnFile: any) => {
     const [xmlData, setXmlData] = useState<string>("")
@@ -92,17 +92,13 @@ const useBpmnFile = (bpmnFile: any) => {
                         }
                     }, {} as Gateways)
                 setGateways(gateways)
-                
+
                 const eventsFromModel = elementRegistry
                     .filter((e: { type: string; }) => e.type === 'bpmn:IntermediateCatchEvent')
                     .reduce((acc: EventsFromModel, t: any) => {
-                        const new_acc = {
-                            ...acc,
-                            [t.id]: { name: t.businessObject?.name }
-                        } as EventsFromModel
-
-                        return new_acc
-                    }, {} as EventsFromModel)
+                        acc.add(t.id, new EventDetails({ name: t.businessObject?.name ?? ""}))
+                        return acc
+                    }, new EventsFromModel())
                 
                 setEventsFromModel(eventsFromModel)
             }

--- a/src/components/simulationParameters/useFormState.ts
+++ b/src/components/simulationParameters/useFormState.ts
@@ -229,7 +229,7 @@ const useFormState = (tasksFromModel: AllModelTasks, gateways: Gateways, eventsF
 
             let mappedEvents: EventDistribution[] = []
             if (eventsFromModel !== undefined) {
-                const eventIdsArr = Object.keys(eventsFromModel)
+                const eventIdsArr = eventsFromModel.getAllKeys()
                 mappedEvents = eventIdsArr.map((eventId) => {
                     return {
                         event_id: eventId,

--- a/src/components/simulationParameters/useJsonFile.ts
+++ b/src/components/simulationParameters/useJsonFile.ts
@@ -40,7 +40,7 @@ const useJsonFile = (jsonFile: any, eventsFromModel?: EventsFromModel) => {
  * If an event exists in json but not in BPMN   - we ignore it and show the warning.
  */
 const getMergeEventsList = (eventsFromModel: EventsFromModel, eventsConfig: any) => {
-    const eventsArr = Object.keys(eventsFromModel)
+    const eventsArr = eventsFromModel.getAllKeys()
     if (eventsArr.length === 0) {
         // no events in the BPMN model
         const events_config_num = eventsConfig ? eventsConfig.length : 0

--- a/src/components/simulationParameters/useTabVisibility.ts
+++ b/src/components/simulationParameters/useTabVisibility.ts
@@ -1,0 +1,64 @@
+import { useEffect, useState } from "react";
+import { Dictionary, EventsFromModel } from "../modelData";
+
+export enum TABS {
+    CASE_CREATION,
+    RESOURCE_CALENDARS,
+    RESOURCES,
+    RESOURCE_ALLOCATION,
+    BRANCHING_PROB,
+    INTERMEDIATE_EVENTS,
+    BATCHING,
+    SIMULATION_RESULTS
+}
+
+const tabsName : { [key: string]: string } = {
+    CASE_CREATION: "Case Creation",
+    RESOURCE_CALENDARS: "Resource Calendars",
+    RESOURCES: "Resources",
+    RESOURCE_ALLOCATION: "Resource Allocation",
+    BRANCHING_PROB: "Branching Probabilities",
+    INTERMEDIATE_EVENTS: "Intermediate Events",
+    BATCHING: "Batching",
+    SIMULATION_RESULTS: "Simulation Results"
+};
+
+const useTabVisibility = (eventsFromModel?: EventsFromModel) => {
+    const [ visibleTabs, setVisibleTabs ] = useState(new Dictionary<string>())
+    const [ isEventsTabHidden, setIsEventsTabHidden ] = useState<boolean | undefined>(undefined)
+
+    useEffect(() => {
+        if (eventsFromModel === undefined)
+            return
+
+        const areEventsEmpty = eventsFromModel.isEmpty()
+        if (areEventsEmpty !== isEventsTabHidden) {
+            setIsEventsTabHidden(areEventsEmpty)
+        }
+    }, [eventsFromModel])
+
+    useEffect(() => {
+        if (isEventsTabHidden === undefined || !visibleTabs.isEmpty()) {
+            // skip initialization if
+            // 1) no information yet loaded
+            // 2) we already have a final array
+            return 
+        }
+
+        const newVisibleTabs = Object.entries(tabsName).reduce((acc: Dictionary<string>, [key, value]: any) => {
+            if (key === TABS[TABS.INTERMEDIATE_EVENTS] && isEventsTabHidden) {
+                // section is hidden, we don't add it to the general list
+                return acc
+            }
+
+            acc.add(key, value)
+            return acc
+        }, new Dictionary<string>())
+
+        setVisibleTabs(newVisibleTabs)
+    }, [isEventsTabHidden, visibleTabs])
+
+    return {visibleTabs}
+}
+
+export default useTabVisibility;


### PR DESCRIPTION
In case BPMN model doesn't have any intermediate events, the `Intermediate Events` tab is hidden from the user because it will be empty in this case. 