### PR TITLE
#83 - Resource Calendars improvements

### DIFF
--- a/src/components/ResourceCalendars.tsx
+++ b/src/components/ResourceCalendars.tsx
@@ -32,7 +32,7 @@ const ResourceCalendars = (props: ResourceCalendarsProps) => {
         name: "resource_calendars"
     })
 
-    const onAddNewCalendar = () => {
+    const onNameDialogOpen = () => {
         setIsNameDialogOpen(true)
     };
 
@@ -42,6 +42,19 @@ const ResourceCalendars = (props: ResourceCalendarsProps) => {
             setAssignedCalendars(usedCalendars)
         }
     }, [])
+
+    useEffect(() => {
+        // once we get the new number of calendars, we:
+        // either created a new one and redirect users to this newly created resource
+        // or loading the page for the first time and select the first calendar in the list as an active one
+        setCurrCalendarIndex(0)
+    }, [allCalendars])
+
+    useEffect(() => {
+        // once index of the selected calendar changed,
+        // we need to update the key accordingly
+        updateCurrKey(currCalendarIndex)
+    }, [currCalendarIndex])
 
     const onDeleteCalendars = () => {
         if (currCalendarIndex === undefined) {
@@ -65,10 +78,14 @@ const ResourceCalendars = (props: ResourceCalendarsProps) => {
     };
 
     const onNameDialogSave = (name: string) => {
+        // nullify selected option
+        updateCurrCalendar(undefined)
+
+        // add new calendar as the first one in the list
         const newDefaultResourceCalendar = defaultTemplateSchedule(false, name)
         prependCalendarFields(newDefaultResourceCalendar)
-        updateCurrCalendar(0)
-        setIsNameDialogOpen(false)
+
+        onNameDialogClose()
     };
 
     const onNameDialogClose = () => {
@@ -80,13 +97,19 @@ const ResourceCalendars = (props: ResourceCalendarsProps) => {
         updateCurrCalendar(Number(selectedCalendarIndex))
     }
 
-    const updateCurrCalendar = (index: number | undefined) => {
+    const updateCurrCalendar = (index?: number) => {
+        // update index
         setCurrCalendarIndex(index)
 
-        if (index === undefined) {
+        // update key
+        updateCurrKey(index)
+    }
+
+    const updateCurrKey = (currIndex?: number) => {
+        if (currIndex === undefined) {
             setCurrCalendarKey("")
         } else {
-            const calendarKey = allCalendars[index]?.key || ""
+            const calendarKey = allCalendars[currIndex]?.key || ""
             setCurrCalendarKey(calendarKey)
         }
     }
@@ -124,7 +147,7 @@ const ResourceCalendars = (props: ResourceCalendarsProps) => {
                 </Grid>
                 <Grid item xs={2} className={classes.centeredGrid}>
                     <AddButtonToolbar
-                        onClick={onAddNewCalendar}
+                        onClick={onNameDialogOpen}
                         labelName="new calendar"
                         variant="text"
                         tooltipText="Add new calendar"
@@ -132,12 +155,12 @@ const ResourceCalendars = (props: ResourceCalendarsProps) => {
                 </Grid>
             </Grid>
             {(currCalendarIndex === undefined)
-                ? <Grid xs={12} className={classes.centeredGrid} sx={{ p: 2 }}>
+                ? <Grid item xs={12} className={classes.centeredGrid} sx={{ p: 2 }}>
                     <Typography>
                         Please select the calendar to see its time periods
                     </Typography>
                 </Grid>
-                : <Grid xs={12} sx={{ p: 2 }}>
+                : <Grid item xs={12} sx={{ p: 2 }}>
                     <TimePeriodList
                         key={`resource_calendars.${currCalendarKey}`}
                         formState={formState}

--- a/src/components/calendars/assignedCalendarsCollector.ts
+++ b/src/components/calendars/assignedCalendarsCollector.ts
@@ -1,0 +1,19 @@
+import { ResourcePool } from "../formData";
+
+/**
+* Collect all unique calendars assigned to a resource in resource profiles
+*
+* @param {ResourcePool[]} resourceProfiles - array of all defined resource profiles
+* @returns {Set<string>} Set of unique calendars name
+*/
+export const collectAllAssignedCalendars = (resourceProfiles: ResourcePool[]) => {
+    const collectedCalendars: Set<string> = new Set()
+
+    for (const profile of resourceProfiles) {
+        for (const resource of profile.resource_list) {
+            collectedCalendars.add(resource.calendar)
+        }
+    }
+
+    return collectedCalendars
+}


### PR DESCRIPTION
- restrict users from deleting a resource calendar in case it is assigned to one of the resource
- fix case when adding a new calendar at the same time when the first calendar is selected, resulted in the incorrect set of time periods. Now, the user is being shown the first calendar on the page's first load. Also, when deleting a calendar, the selection automatically will be changed to the first one. This means that we select the first calendar in the list if the number of calendars changes. 